### PR TITLE
Firefox fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is completely open source: https://github.com/sw-yx/async-render-toolbox I 
 
 ### Install the Chrome extension [here](https://chrome.google.com/webstore/detail/fbchcodfbfjeededacomngobhnndcgol)
 
-### Install the Firefox extension [here](https://addons.mozilla.org/en-US/developers/addon/async-render-toolbox/)
+### Install the Firefox extension [here](https://addons.mozilla.org/en-US/firefox/addon/async-render-toolbox/)
 
 Then:
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,9 @@
     "scripts": ["background.js"],
     "persistent": false
   },
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html"
+  },
   "homepage_url": "https://github.com/sw-yx/async-render-toolbox",
   "incognito": "spanning",
   "manifest_version": 2


### PR DESCRIPTION
Just two small fixes for Firefox.

People should now be able to actually follow the link to AMO and download the extension.
Furthermore, this PR gets rid of one error message regarding the use of ``options_page`` (which isn't implemented in Firefox and generally considered deprecated by Google Chrome developers).